### PR TITLE
Operator prisms

### DIFF
--- a/abt.cabal
+++ b/abt.cabal
@@ -23,6 +23,7 @@ library
                        Abt.Tutorial
   build-depends:       base >=4.7 && <4.8,
                        vinyl >=0.5,
+                       profunctors >=4.3.2,
                        transformers
   ghc-options:         -Wall
   hs-source-dirs:      src

--- a/src/Abt/Class/HEq1.hs
+++ b/src/Abt/Class/HEq1.hs
@@ -1,19 +1,42 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnicodeSyntax #-}
 
 module Abt.Class.HEq1 where
 
+import Control.Applicative
 import Data.Vinyl
+
+-- | Essentially, Martin-Löf's identity type.
+--
+data a :=: b where
+  Refl ∷ a :=: a
+
+-- | Type constructors are extensional.
+--
+cong ∷ a :=: b → f a :=: f b
+cong Refl = Refl
 
 -- | Uniform variant of 'Eq' for indexed types. This is different from
 -- 'Data.Functor.Eq1' in that it is properly kind polymorphic and crucially
--- heterogeneous, and it places no constraint on the index.
+-- heterogeneous, and it places no constraint on the index. Because it is
+-- heterogeneous, it is useful to project equality in the base space from
+-- equality in the total space.
 --
 class HEq1 f where
+  -- | When both sides are equal, give in addition a proof that their indices
+  -- are equal; otherwise return 'Nothing'.
+  --
+  heq1 ∷ f i → f j → Maybe (i :=: j)
+
+  -- | A boolean version of 'heq1', which must agree with it.
+  --
   (===) ∷ f i → f j → Bool
+  x === y = maybe False (const True) $ heq1 x y
 
 instance HEq1 el ⇒ HEq1 (Rec el) where
-  RNil === RNil = True
-  (x :& xs) === (y :& ys) = x === y && xs === ys
-  _ === _ = False
+  heq1 RNil RNil = Just Refl
+  heq1 (x :& xs) (y :& ys)
+    | Just Refl ← heq1 x y = cong <$> heq1 xs ys
+  heq1 _ _ = Nothing

--- a/src/Abt/Concrete/LocallyNameless.hs
+++ b/src/Abt/Concrete/LocallyNameless.hs
@@ -46,7 +46,7 @@ instance Ord Var where
 -- | A lens for '_varName'.
 --
 -- @
--- varName ∷ Lens' 'Var' ('Maybe' 'String')
+-- 'varName' ∷ Lens' 'Var' ('Maybe' 'String')
 -- @
 --
 varName
@@ -61,7 +61,7 @@ varName i (Var n j) =
 -- | A lens for '_varIndex'.
 --
 -- @
--- varIndex ∷ Lens' 'Var' 'Int'
+-- 'varIndex' ∷ Lens' 'Var' 'Int'
 -- @
 --
 varIndex
@@ -133,7 +133,7 @@ instance Show1 o ⇒ Abt Var o (Tm o) where
 -- | A prism to extract arguments from a proposed operator.
 --
 -- @
--- _TmOp ∷ HEq1 o ⇒ o ns → Prism' (Tm0 o) (Rec (Tm0 o) ns)
+-- '_TmOp' ∷ 'HEq1' o ⇒ o ns → Prism' ('Tm0' o) ('Rec' ('Tm0' o) ns)
 -- @
 --
 _TmOp

--- a/src/Abt/Concrete/LocallyNameless.hs
+++ b/src/Abt/Concrete/LocallyNameless.hs
@@ -9,6 +9,7 @@
 module Abt.Concrete.LocallyNameless
 ( Tm(..)
 , Tm0
+, _TmOp
 , Var(..)
 , varName
 , varIndex
@@ -22,6 +23,7 @@ import Abt.Class.Abt
 import Abt.Class.Monad
 
 import Control.Applicative
+import Data.Profunctor
 import Data.Vinyl
 
 -- | A variable is a De Bruijn index, optionally decorated with a display name.
@@ -84,11 +86,13 @@ data Tm (o ∷ [Nat] → *) (n ∷ Nat) where
 type Tm0 o = Tm o Z
 
 instance HEq1 o ⇒ HEq1 (Tm o) where
-  Free v1 === Free v2 = v1 == v2
-  Bound m === Bound n = m == n
-  Abs e1 === Abs e2 = e1 === e2
-  App o1 es1 === App o2 es2 = o1 === o2 && es1 === es2
-  _ === _ = False
+  heq1 (Free v1) (Free v2) | v1 == v2 = Just Refl
+  heq1 (Bound m) (Bound n) | m == n = Just Refl
+  heq1 (Abs e1) (Abs e2) = cong <$> heq1 e1 e2
+  heq1 (App o1 es1) (App o2 es2)
+    | Just Refl ← heq1 o1 o2
+    , Just Refl ← heq1 es1 es2 = Just Refl
+  heq1 _ _ = Nothing
 
 shiftVar
   ∷ Var
@@ -125,3 +129,23 @@ instance Show1 o ⇒ Abt Var o (Tm o) where
       v ← fresh
       return $ v :\ addVar v 0 e
     App p es → return $ p :$ es
+
+-- | A prism to extract arguments from a proposed operator.
+--
+-- @
+-- _TmOp ∷ HEq1 o ⇒ o ns → Prism' (Tm0 o) (Rec (Tm0 o) ns)
+-- @
+--
+_TmOp
+  ∷ ( Choice p
+    , Applicative f
+    , HEq1 o
+    )
+  ⇒ o ns
+  → p (Rec (Tm o) ns) (f (Rec (Tm o) ns))
+  → p (Tm0 o) (f (Tm0 o))
+_TmOp o = dimap fro (either pure (fmap (App o))) . right'
+  where
+    fro = \case
+      App o' es | Just Refl ← heq1 o o' → Right es
+      e → Left e

--- a/src/Abt/Tutorial.hs
+++ b/src/Abt/Tutorial.hs
@@ -58,9 +58,9 @@ instance Show1 Lang where
     APP → "ap"
 
 instance HEq1 Lang where
-  LAM === LAM = True
-  APP === APP = True
-  _ === _ = False
+  heq1 LAM LAM = Just Refl
+  heq1 APP APP = Just Refl
+  heq1 _ _ = Nothing
 
 lam ∷ Tm Lang (S Z) → Tm0 Lang
 lam e = LAM $$ e :& RNil

--- a/src/Abt/Types/View.hs
+++ b/src/Abt/Types/View.hs
@@ -49,7 +49,7 @@ mapView η = \case
 -- | A prism to extract arguments from a proposed operator.
 --
 -- @
--- _ViewOp ∷ HEq1 o ⇒ o ns → Prism' (View0 v o φ) (Rec φ ns)
+-- '_ViewOp' ∷ 'HEq1' o ⇒ o ns → Prism' ('View0' v o φ) ('Rec' φ ns)
 -- @
 --
 _ViewOp


### PR DESCRIPTION
This seems pretty useful; the only reason to not do it would be to avoid incurring a dependency on `profunctors`.

In order to make it safe, I had to rejigger `HEq1` to require proofs that indices `i,j` are equal whenever we wish to say that terms `<i,M>, <j,N>` are equal in the total space of an indexed type.